### PR TITLE
Count sums using the parallel addition trick

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -57,6 +57,8 @@ int main(int, char**) {
   auto t7 = std::chrono::high_resolution_clock::now();
   auto multiply_filter_answer = multiply_filter(buf.data(), buf.size());
   auto t8 = std::chrono::high_resolution_clock::now();
+  auto parallel_add_lookup_answer = parallel_add_lookup(buf.data(), buf.size());
+  auto t9 = std::chrono::high_resolution_clock::now();
 
   if(simple_answer != correct_answer) {
     printf("Simple loop produced wrong answer: %ld\n", (long)simple_answer);
@@ -121,6 +123,14 @@ int main(int, char**) {
   } else {
     int64_t count = std::chrono::duration_cast<std::chrono::microseconds>(t8-t7).count();
     printf("Multi took %ld μs\n", (long)count);
+  }
+
+  if(parallel_add_lookup_answer != correct_answer) {
+    printf("Parallel_add_lookup produced wrong answer: %ld\n", (long)parallel_add_lookup_answer);
+    failed++;
+  } else {
+    int64_t count = std::chrono::duration_cast<std::chrono::microseconds>(t9-t8).count();
+    printf("Parallel add lookup took %ld μs\n", (long)count);
   }
 
   return failed;

--- a/speedup.hpp
+++ b/speedup.hpp
@@ -27,6 +27,7 @@ uint64_t lookup_table(const uint8_t *buf, size_t bufsize);
 uint64_t bit_fiddling(const uint8_t *buf, size_t bufsize);
 uint64_t bucket(const uint8_t *buf, size_t bufsize);
 uint64_t multiply_filter(const uint8_t *buf, size_t bufsize);
+uint64_t parallel_add_lookup(const uint8_t *buf, size_t bufsize);
 
 /* Mutating functions */
 


### PR DESCRIPTION
Tested on i5-6600k. 

GCC 5.4.0: This is the fastest without optimization and
pretty close on -O2 and -O3. For some reason, -O2 is slightly faster
than -O3.

Clang 3.8.0: Again, fastest with optimization. Pretty bad with -O2,
closer to top but not winner on -O3.

The amount of bitwise operation is horrible and isn't really optimized
at assembly level, probably some kind of superscalarity happens in the
CPU.

This could be easily converted to AVX, but I consider it as
semi-assembly and against the rules.