### PR TITLE
Leave out unnecessary masks, add explanation

### DIFF
--- a/speedup.cpp
+++ b/speedup.cpp
@@ -114,7 +114,7 @@ uint64_t zeroing(uint8_t *buf, size_t bufsize) {
   return result;
 }
 
-inline uint64_t mask(uint8_t i) {
+inline uint64_t bytemask(uint8_t i) {
   return i ? 0xff : 0x0;
 }
 
@@ -123,10 +123,10 @@ uint64_t parallel_add_lookup(const uint8_t *buf, size_t bufsize) {
   std::array<uint64_t, 256> masks;
   for (size_t i = 0; i < 256; i++) {
     // Bit reverse and reverse: see below
-    masks[i] = mask((i >> 7) & 0x01) << 0 | mask((i >> 6) & 0x01) << 32 |
-               mask((i >> 5) & 0x01) << 16 | mask((i >> 4) & 0x01) << 48 |
-               mask((i >> 3) & 0x01) << 8 | mask((i >> 2) & 0x01) << 40 |
-               mask((i >> 1) & 0x01) << 24 | mask(i & 0x01) << 56;
+    masks[i] = bytemask((i >> 7) & 0x01) << 0 | bytemask((i >> 6) & 0x01) << 32 |
+               bytemask((i >> 5) & 0x01) << 16 | bytemask((i >> 4) & 0x01) << 48 |
+               bytemask((i >> 3) & 0x01) << 8 | bytemask((i >> 2) & 0x01) << 40 |
+               bytemask((i >> 1) & 0x01) << 24 | bytemask(i & 0x01) << 56;
   }
   uint64_t result = 0;
   const uint64_t *b = reinterpret_cast<const uint64_t *>(buf);
@@ -134,20 +134,24 @@ uint64_t parallel_add_lookup(const uint8_t *buf, size_t bufsize) {
   for (size_t i = 0; i < bufsize / 8; i++) {
     uint64_t x = b[i];
     // Only highest bits of each byte set
-    uint64_t maskin = x & (0x8080808080808080ul);
+    uint64_t mask = x & (0x8080808080808080ul);
 
     // Wrap highest bits to bit-reverse reverse order. The additional
-    // reverse saves us one shift for each round. Original bit order:
-    // a..b..c..d..e..f..g..h..
-    maskin = (maskin & 0xFFFFFFFFul) | (maskin >> 33);
-    // ea..fb..gc..hd
-    maskin = (maskin & 0xFFFFul) | (maskin >> 18);
-    // gcea..hdfb..
-    maskin = (maskin & 0xFFul) | (maskin >> 12);
+    // reverse saves us one shift for each round. Bit order before and
+    // after each shift in comments.
+    // a.......b.......c.......d.......e.......f.......g.......h.......
+    mask |= (mask >> 33);
+    // a.......b.......c.......d.......ea......fb......gc......hd......
+    mask |= (mask >> 18);
+    // a.......b.......c.a.....d.b.....eac.....fbd.....gcea....hdfb....
+    mask |= (mask >> 12);
+    // a.......b...a...c.a.b...d.b.c.a.eac.d.b.fbd.eac.gceafbd.hdfbgcea
+
+    mask &= 0xFFul;
     // hdfbgcea
 
     // Mask out bytes < 127
-    x &= masks[maskin];
+    x &= masks[mask];
     // Sum bytes in parallel
     x = ((x & 0xFF00FF00FF00FF00ul) >> 8) + (x & 0x00FF00FF00FF00FFul);
     x = ((x & 0xFFFF0000FFFF0000ul) >> 16) + (x & 0x0000FFFF0000FFFFul);


### PR DESCRIPTION
Once more, this improves perf on clang 3.8.0 to near simple lookup very slight disadvantage with GCC 5.4.0.

The super weird part: On i5-6600K and zero optimization, the version
with extra masks is faster than this. Both are compiled to very straight
forward assembly, the faster version just has some extra and instructions.