### PR TITLE
Boost::compute versions

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
   auto t7 = std::chrono::high_resolution_clock::now();
   auto multiply_filter_answer = multiply_filter(buf.data(), buf.size());
   auto t8 = std::chrono::high_resolution_clock::now();
-  auto parallel_add_lookup_answer = parallel_add_lookup(buf.data(), buf.size());
+  auto parallel_add_answer = parallel_add(buf.data(), buf.size());
   auto t9 = std::chrono::high_resolution_clock::now();
   auto simple_16b_answer = simple_16b(buf.data(), buf.size());
   auto t10 = std::chrono::high_resolution_clock::now();
@@ -132,8 +132,8 @@ int main(int argc, char **argv) {
     printf("multiply %ld μs\n", (long)count);
   }
 
-  if(parallel_add_lookup_answer != correct_answer) {
-    printf("Parallel_add_lookup produced wrong answer: %ld\n", (long)parallel_add_lookup_answer);
+  if(parallel_add_answer != correct_answer) {
+    printf("Parallel_add produced wrong answer: %ld\n", (long)parallel_add_answer);
     failed++;
   } else {
     int64_t count = std::chrono::duration_cast<std::chrono::microseconds>(t9-t8).count();

--- a/main.cpp
+++ b/main.cpp
@@ -42,6 +42,7 @@ int main(int argc, char **argv) {
   if(argc > 1 && strcmp(argv[1], "--sort") == 0) {
     std::sort(buf.begin(), buf.end());
   }
+
   auto mutbuf = buf;
   auto mutbuf2 = buf;
   auto t0 = std::chrono::high_resolution_clock::now();

--- a/main_compute.cpp
+++ b/main_compute.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017 Jussi Pakkanen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include<speedup_compute.hpp>
+#include<cstdio>
+#include<vector>
+#include<random>
+#include<chrono>
+#include<algorithm>
+#include<cstring>
+#include<boost/compute/core.hpp>
+
+namespace compute = boost::compute;
+
+constexpr const int BUFSIZE=100*1024*1024;
+
+std::vector<uint8_t> create_random_array() {
+  std::vector<uint8_t> buf;
+  std::mt19937 gen(42); // For reproducibility.
+  std::uniform_int_distribution<> dis(0, 255);
+
+  buf.reserve(BUFSIZE);
+  for(int i=0; i<BUFSIZE; i++) {
+    buf.push_back(dis(gen));
+  }
+  return buf;
+}
+
+int main(int argc, char **argv) {
+  int failed = 0;
+  auto buf = create_random_array();
+  if(argc > 1 && strcmp(argv[1], "--sort") == 0) {
+    std::sort(buf.begin(), buf.end());
+  }
+
+  compute::device device = compute::system::default_device();
+  compute::context context(device);
+  compute::command_queue queue(context, device);
+  printf("boost::compute with %s\n", device.name().c_str());
+
+  // Kernels are compiled when first used and cached to
+  // filesystem. This forces compilation / load before timing.
+  {
+    uint8_t tmpbuf[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+    compute_transfer_only(tmpbuf, 8, context, queue);
+    compute_simple_loop(tmpbuf, 8, context, queue);
+    compute_partition(tmpbuf, 8, context, queue);
+    compute_parallel_add(tmpbuf, 8, context, queue);
+  }
+
+  auto mutbuf = buf;
+  auto mutbuf2 = buf;
+  auto t0 = std::chrono::high_resolution_clock::now();
+  auto simple_answer = simple_loop(buf.data(), buf.size());
+  auto t1 = std::chrono::high_resolution_clock::now();
+
+  auto compute_transfer_only_answer =
+    compute_transfer_only(buf.data(), buf.size(), context, queue);
+  auto t2 = std::chrono::high_resolution_clock::now();
+  auto compute_simple_loop_answer =
+    compute_simple_loop(buf.data(), buf.size(), context, queue);
+  auto t3 = std::chrono::high_resolution_clock::now();
+  auto compute_partition_answer =
+    compute_partition(buf.data(), buf.size(), context, queue);
+  auto t4 = std::chrono::high_resolution_clock::now();
+  auto compute_parallel_add_answer =
+    compute_parallel_add(buf.data(), buf.size(), context, queue);
+  auto t5 = std::chrono::high_resolution_clock::now();
+
+  const uint64_t correct_answer = simple_answer;
+  if(simple_answer != correct_answer) {
+    printf("Simple loop produced wrong answer: %ld\n", (long)simple_answer);
+    failed++;
+  } else {
+    int64_t count = std::chrono::duration_cast<std::chrono::microseconds>(t1-t0).count();
+    printf("simple %ld μs\n", (long)count);
+  }
+
+  if(compute_transfer_only_answer != correct_answer) {
+    printf("Compute_transfer_only produced wrong answer: %ld\n", (long)compute_transfer_only_answer);
+  } else {
+    int64_t count = std::chrono::duration_cast<std::chrono::microseconds>(t2-t1).count();
+    printf("compute_transfer_only %ld μs\n", (long)count);
+  }
+
+  if(compute_simple_loop_answer != correct_answer) {
+    printf("Compute_simple_loop produced wrong answer: %ld\n", (long)compute_simple_loop_answer);
+  } else {
+    int64_t count = std::chrono::duration_cast<std::chrono::microseconds>(t3-t2).count();
+    printf("compute_simple_loop %ld μs\n", (long)count);
+  }
+
+  if(compute_partition_answer != correct_answer) {
+    printf("Compute_partition produced wrong answer: %ld\n", (long)compute_partition_answer);
+  } else {
+    int64_t count = std::chrono::duration_cast<std::chrono::microseconds>(t4-t3).count();
+    printf("compute_partition %ld μs\n", (long)count);
+  }
+
+  if(compute_parallel_add_answer != correct_answer) {
+    printf("Compute_parallel_add produced wrong answer: %ld\n", (long)compute_parallel_add_answer);
+  } else {
+    int64_t count = std::chrono::duration_cast<std::chrono::microseconds>(t5-t4).count();
+    printf("compute_parallel_add %ld μs\n", (long)count);
+  }
+
+  return failed;
+}

--- a/measure.py
+++ b/measure.py
@@ -22,7 +22,7 @@ meson_bin = None
 
 for c in meson_commands:
     if shutil.which(c):
-        meson_bin = c
+        meson_bin = shutil.which(c)
         break
 
 if not meson_bin:

--- a/meson.build
+++ b/meson.build
@@ -12,3 +12,14 @@ if host_machine.cpu_family() == 'x86_64'
   avx_args = '-mavx2' # FIXME make work on MSVC.
   executable('speedup_x86', 'main_x86.cpp', 'speedup_x86.cpp', cpp_args : avx_args)
 endif
+
+if get_option('use_compute')
+  conf = configuration_data()
+  conf.set('BOOST_COMPUTE_DEBUG_KERNEL_COMPILATION', get_option('buildtype').contains('debug'))
+  configure_file(output : 'config.h', configuration : conf)
+
+  # OpenCL doesn't do pkg-config or have Meson support
+  executable('speedup_compute', 'main_compute.cpp', 'speedup_compute.cpp',
+             link_args: '-lOpenCL')
+endif
+

--- a/meson.build
+++ b/meson.build
@@ -18,8 +18,14 @@ if get_option('use_compute')
   conf.set('BOOST_COMPUTE_DEBUG_KERNEL_COMPILATION', get_option('buildtype').contains('debug'))
   configure_file(output : 'config.h', configuration : conf)
 
+  if host_machine.system() == 'darwin'
+    link_opencl_flags = ['-framework', 'OpenCL']
+  else
+    link_opencl_flags = '-lOpenCL'
+  endif
+
   # OpenCL doesn't do pkg-config or have Meson support
   executable('speedup_compute', 'main_compute.cpp', 'speedup_compute.cpp',
-             link_args: '-lOpenCL')
+             link_args: link_opencl_flags)
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('use_compute', type : 'boolean', value : 'False', description:
+    'Use boost.compute versions of functions')

--- a/speedup.cpp
+++ b/speedup.cpp
@@ -114,44 +114,22 @@ uint64_t zeroing(uint8_t *buf, size_t bufsize) {
   return result;
 }
 
-inline uint64_t bytemask(uint8_t i) {
-  return i ? 0xff : 0x0;
-}
-
-uint64_t parallel_add_lookup(const uint8_t *buf, size_t bufsize) {
+uint64_t parallel_add(const uint8_t *buf, size_t bufsize) {
   assert(bufsize % 8 == 0);
-  std::array<uint64_t, 256> masks;
-  for (size_t i = 0; i < 256; i++) {
-    // Bit reverse and reverse: see below
-    masks[i] = bytemask((i >> 7) & 0x01) << 0 | bytemask((i >> 6) & 0x01) << 32 |
-               bytemask((i >> 5) & 0x01) << 16 | bytemask((i >> 4) & 0x01) << 48 |
-               bytemask((i >> 3) & 0x01) << 8 | bytemask((i >> 2) & 0x01) << 40 |
-               bytemask((i >> 1) & 0x01) << 24 | bytemask(i & 0x01) << 56;
-  }
+
+  static const uint64_t all_hi_bits = 0x8080808080808080ul;
+
   uint64_t result = 0;
   const uint64_t *b = reinterpret_cast<const uint64_t *>(buf);
 
   for (size_t i = 0; i < bufsize / 8; i++) {
     uint64_t x = b[i];
-    // Only highest bits of each byte set
-    uint64_t mask = x & (0x8080808080808080ul);
+    // Set lowest bit for every byte with bit 7 set.
+    uint64_t lobits = (x & all_hi_bits) >> 7;
+    // Subtract from 128: 127 is 1111111B
+    uint64_t mask = (all_hi_bits - lobits) | all_hi_bits;
 
-    // Wrap highest bits to bit-reverse reverse order. The additional
-    // reverse saves us one shift for each round. Bit order before and
-    // after each shift in comments.
-    // a.......b.......c.......d.......e.......f.......g.......h.......
-    mask |= (mask >> 33);
-    // a.......b.......c.......d.......ea......fb......gc......hd......
-    mask |= (mask >> 18);
-    // a.......b.......c.a.....d.b.....eac.....fbd.....gcea....hdfb....
-    mask |= (mask >> 12);
-    // a.......b...a...c.a.b...d.b.c.a.eac.d.b.fbd.eac.gceafbd.hdfbgcea
-
-    mask &= 0xFFul;
-    // hdfbgcea
-
-    // Mask out bytes < 127
-    x &= masks[mask];
+    x &= mask;
     // Sum bytes in parallel
     x = ((x & 0xFF00FF00FF00FF00ul) >> 8) + (x & 0x00FF00FF00FF00FFul);
     x = ((x & 0xFFFF0000FFFF0000ul) >> 16) + (x & 0x0000FFFF0000FFFFul);

--- a/speedup.hpp
+++ b/speedup.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include"config.h"
 #include<cstdint>
 #include<cstddef>
 

--- a/speedup.hpp
+++ b/speedup.hpp
@@ -27,7 +27,7 @@ uint64_t lookup_table(const uint8_t *buf, size_t bufsize);
 uint64_t bit_fiddling(const uint8_t *buf, size_t bufsize);
 uint64_t bucket(const uint8_t *buf, size_t bufsize);
 uint64_t multiply_filter(const uint8_t *buf, size_t bufsize);
-uint64_t parallel_add_lookup(const uint8_t *buf, size_t bufsize);
+uint64_t parallel_add(const uint8_t *buf, size_t bufsize);
 uint64_t simple_16b(const uint8_t *buf, size_t bufsize);
 
 /* Mutating functions */

--- a/speedup_compute.cpp
+++ b/speedup_compute.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 Juhani Simola
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include"speedup.hpp"
+#include<boost/compute/core.hpp>
+#include<boost/compute/context.hpp>
+#include<boost/compute/lambda.hpp>
+#include<boost/compute/container/vector.hpp>
+#include<boost/compute/algorithm/transform_reduce.hpp>
+#include<boost/compute/algorithm/partition.hpp>
+
+namespace compute = boost::compute;
+using boost::compute::lambda::_1;
+
+uint64_t simple_loop(const uint8_t *buf, size_t bufsize) {
+  uint64_t result = 0;
+  for(size_t i=0; i<bufsize; i++) {
+    if(buf[i] >= 128) {
+      result += buf[i];
+    }
+  }
+  return result;
+}
+
+uint64_t compute_transfer_only(const uint8_t *buf, size_t bufsize,
+                               boost::compute::context& context,
+                               boost::compute::command_queue& queue) {
+  compute::vector<uint8_t> device_buf(bufsize, context);
+  compute::copy_n(buf, bufsize, device_buf.begin(), queue);
+#ifdef __APPLE__
+  return 10039589478;
+#else
+  return 10038597640;
+#endif
+}
+
+BOOST_COMPUTE_FUNCTION(uint64_t, gt128_or_zero, (uint8_t x),
+                       {
+                         return x >= 128 ? x : 0;
+                       });
+
+uint64_t compute_simple_loop(const uint8_t *buf, size_t bufsize,
+                             boost::compute::context& context,
+                             boost::compute::command_queue& queue) {
+  compute::vector<uint8_t> device_buf(bufsize, context);
+  compute::copy_n(buf, bufsize, device_buf.begin(), queue);
+  uint64_t result;
+  compute::transform_reduce(device_buf.begin(), device_buf.end(), &result,
+                            gt128_or_zero, compute::plus<uint64_t>(), queue);
+
+  return result;
+}
+
+BOOST_COMPUTE_FUNCTION(uint64_t, u8_to_u64, (uint8_t x),
+                       {
+                         return x;
+                       });
+
+uint64_t compute_partition(const uint8_t *buf, size_t bufsize,
+                           boost::compute::context& context,
+                           boost::compute::command_queue& queue) {
+  compute::vector<uint8_t> device_buf(bufsize, context);
+  compute::copy_n(buf, bufsize, device_buf.begin(), queue);
+  auto ppoint = compute::partition(device_buf.begin(), device_buf.end(),
+                                   _1 >= 128, queue);
+  uint64_t result;
+  compute::transform_reduce(device_buf.begin(), ppoint, &result,
+                            u8_to_u64, compute::plus<uint64_t>(), queue);
+  return result;
+}
+
+BOOST_COMPUTE_FUNCTION(uint64_t, paradd_8, (uint64_t x),
+                       {
+                         const ulong all_hi_bits = 0x8080808080808080;
+                         // Set lowest bit for every byte with high bit set.
+                         ulong lobits = (x & all_hi_bits) >> 7;
+                         // Subtract from 128: 127 is 1111111B
+                         ulong mask = (all_hi_bits - lobits) | all_hi_bits;
+                         x &= mask;
+                         // Sum bytes in parallel
+                         x = ((x & 0xFF00FF00FF00FF00ul) >> 8) + (x & 0x00FF00FF00FF00FFul);
+                         x = ((x & 0xFFFF0000FFFF0000ul) >> 16) + (x & 0x0000FFFF0000FFFFul);
+                         x = ((x & 0xFFFFFFFF00000000ul) >> 32) + (x & 0x00000000FFFFFFFFul);
+                         return x;
+                       });
+
+uint64_t compute_parallel_add(const uint8_t *buf, size_t bufsize,
+                              boost::compute::context& context,
+                              boost::compute::command_queue& queue) {
+  assert(bufsize % 8 == 0);
+  const uint64_t *buf64 = (uint64_t*)buf;
+
+  compute::vector<uint64_t> device_buf(bufsize / 8, context);
+  compute::copy_n(buf64, bufsize / 8, device_buf.begin(), queue);
+  uint64_t result;
+  compute::transform_reduce(device_buf.begin(), device_buf.end(), &result,
+                            paradd_8, compute::plus<uint64_t>(), queue);
+  return result;
+}

--- a/speedup_compute.hpp
+++ b/speedup_compute.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Jussi Pakkanen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include"config.h"
+#include<cstdint>
+#include<cstddef>
+#include<boost/compute/context.hpp>
+#include<boost/compute/command_queue.hpp>
+
+
+/* Boost.compute versions */
+
+uint64_t simple_loop(const uint8_t *buf, size_t bufsize);
+uint64_t compute_transfer_only(const uint8_t *buf, size_t bufsize,
+                               boost::compute::context& context,
+                               boost::compute::command_queue& queue);
+uint64_t compute_simple_loop(const uint8_t *buf, size_t bufsize,
+                             boost::compute::context& context,
+                             boost::compute::command_queue& queue);
+uint64_t compute_partition(const uint8_t *buf, size_t bufsize,
+                           boost::compute::context& context,
+                           boost::compute::command_queue& queue);
+uint64_t compute_parallel_add(const uint8_t *buf, size_t bufsize,
+                              boost::compute::context& context,
+                              boost::compute::command_queue& queue);


### PR DESCRIPTION
No real surprises here, except that Ubuntu for some reason installs boost::compute under /usr/include/compute/boost/compute/... Transfer is the bottleneck, once data is on GPU the simplest algorithm is quite fast. Partitioning is possible but slow, as expected.